### PR TITLE
Cleanup riak_dt in the lockfile and bump to 0.0.2

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,10 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0},
- {<<"riak_dt">>,{pkg,<<"riak_dt">>,<<"2.1.1">>},0},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.4.2">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
- {<<"riak_dt">>, <<"56B1898A543C561994F5D052FDEA972525CA98F46FDB3DCDB7366E4F92EE8F54">>},
+ {<<"lager">>, <<"150B9A17B23AE6D3265CC10DC360747621CF217B7A22B8CDDF03B2909DBF7AA5">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>}]}
 ].

--- a/src/lasp_support.app.src
+++ b/src/lasp_support.app.src
@@ -1,7 +1,7 @@
 {application, lasp_support,
  [
   {description, "Support libraries for Lasp from Riak Core."},
-  {vsn, "0.0.1"},
+  {vsn, "0.0.2"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
My previous PR didn't completely remove `riak_dt` from the deps tree because it was in the lockfile. After the version bump, someone should push an updated package to Hex.